### PR TITLE
Fix - Add more regex to narrow the keystone level

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -310,7 +310,7 @@ do
 		if type(raw) ~= "string" then
 			return
 		end
-		local regexesFindLevel = { "%+%s*(%d+)", "(%d+)%s*%+", "(%d+)" }
+		local regexesFindLevel = { "(%d+)%+", "%+%s*(%d+)", "(%d+)%s*%+", "(%d+)" }
 
 		local level = 0;
 		for i, regex in ipairs(regexesFindLevel) do


### PR DESCRIPTION
Hey !

This regex is here to force the search for a keystone level in a title like "15+ 3k", where before +3 would have been selected, 15 will now be selected.