### PR TITLE
Fix - Cancel button being hidden

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -556,6 +556,8 @@ do
 		configScrollFrame:SetPoint("TOPRIGHT", configHeaderFrame, "BOTTOMRIGHT")
 		configScrollFrame:SetHeight(475)
 		configScrollFrame:EnableMouseWheel(true)
+		configScrollFrame:SetClampedToScreen(true);
+		configScrollFrame:SetClipsChildren(true);
 		configScrollFrame:HookScript("OnMouseWheel", function(self, delta)
 			local currentValue = configSliderFrame:GetValue()
 			local changes = -delta * 20


### PR DESCRIPTION
When the `?` and the checkbox were out of the scrollbar, it could still be interacted with, and was causing issue with the Cancel button.

This fix (and mainly the `frame:SetClipsChildren`) make it so that element out of the scrollbar frame can't be interacted with.

Thanks @kaminaris for this :)