### PR TITLE
Add realm to name, if it's not already. Fix #41

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -2331,6 +2331,10 @@ do
 					ShowCustomDropDown(self, dropdown, dropdown.menuList[2].arg1)
 				end
 			elseif dropdown.which and supportedTypes[dropdown.which] then -- UnitPopup
+				if not dropdown.name:find('-') then
+					dropdown.name = dropdown.name .. '-' .. dropdown.server
+				end
+
 				if addonConfig.showDropDownCopyURL then
 					ShowCustomDropDown(self, dropdown, dropdown.chatTarget or dropdown.name, dropdown.unit, dropdown.which, dropdown.bnetIDAccount)
 				end


### PR DESCRIPTION
Hey !

This fix #41 

The issue was : sometimes the realm is not in the dropdown name information (dunno why).
This fix adds it in case it isn't.

(On another note, it could be interesting to use guid instead of player name/realm)