### PR TITLE
Save tooltipArgs before checking for tooltip (except arg1).

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -1345,21 +1345,23 @@ do
 	function AppendGameTooltip(tooltip, arg1, forceNoPadding, forceAddName, forceFaction, focusOnDungeonIndex, focusOnKeystoneLevel)
 		local profile = GetScore(arg1, nil, forceFaction)
 
+		-- setup tooltip hook
+		if not tooltipHooks[tooltip] then
+			tooltipHooks[tooltip] = true
+			tooltip:HookScript("OnTooltipCleared", tooltipHooks.Wipe)
+			tooltip:HookScript("OnHide", tooltipHooks.Wipe)
+		end
+
+		tooltipArgs[2], tooltipArgs[3], tooltipArgs[4], tooltipArgs[5], tooltipArgs[6] = forceNoPadding, forceAddName, forceFaction, focusOnDungeonIndex, focusOnKeystoneLevel
+
 		-- sanity check that the profile exists
 		if profile then
 			-- HOTFIX: ALT-TAB stickyness
 			addon:MODIFIER_STATE_CHANGED(true)
 
-			-- setup tooltip hook
-			if not tooltipHooks[tooltip] then
-				tooltipHooks[tooltip] = true
-				tooltip:HookScript("OnTooltipCleared", tooltipHooks.Wipe)
-				tooltip:HookScript("OnHide", tooltipHooks.Wipe)
-			end
-
 			-- assign the current function args for later use
 			playerTooltip = tooltip
-			tooltipArgs[1], tooltipArgs[2], tooltipArgs[3], tooltipArgs[4], tooltipArgs[5], tooltipArgs[6] = arg1, forceNoPadding, forceAddName, forceFaction, focusOnDungeonIndex, focusOnKeystoneLevel
+			tooltipArgs[1] = arg1
 
 			-- should we show the extended version of the data?
 			local showExtendedTooltip = addon.modKey or addonConfig.alwaysExtendTooltip


### PR DESCRIPTION
Hey ! Here's a fix for #49

The issue was that if a player doesn't have a profile, then the tooltipArgs wasn't saved so when displaying the player's tooltip, it didn't know what to show.

FYI, there's still an issue when creating a group, but I don't really know how you would want to handle it.
The issue is that when forming a group, you technically can't see your profile (we discussed about that when setting that up). So if an applicant doesn't have a profile and your config is set to not position automatically, then it show the profile by default (yours), but doesn't highlight the dungeon.

So, I don't know how you want to handle that !

A possible solution would be that if the position is manual, then instead of displaying the "default profile", it display yours, but not a fan of this solution , as it adds complexity to the code.